### PR TITLE
add Makefiles for Windows and Linux

### DIFF
--- a/backend/Makefile.linux
+++ b/backend/Makefile.linux
@@ -1,0 +1,6 @@
+install:
+	cargo install --path .
+clean:
+	rm target/release/backend.exe
+purge:
+	rm -rf target

--- a/backend/Makefile.win
+++ b/backend/Makefile.win
@@ -1,0 +1,6 @@
+install:
+	cargo install --path .
+clean:
+	del target/release/backend.exe
+purge:
+	del /s target


### PR DESCRIPTION
run make *option*
options are:
   install - runs cargo install in the project directory
   clean - deletes the executable to rebuild it
   pure - removes ALL executables and dependencies, requiring a complete reinstall